### PR TITLE
Remove commit message period

### DIFF
--- a/aicommits.ts
+++ b/aicommits.ts
@@ -117,5 +117,5 @@ async function generateCommitMessage(prompt: string) {
   const json: any = await response.json();
   const aiCommit = json.choices[0].text;
 
-  return aiCommit.replace(/(\r\n|\n|\r)/gm, "");
+  return aiCommit.replace(/(\r\n|\n|\r)/gm, "").replace(/\.$/, "");
 }


### PR DESCRIPTION
### Why

* Maybe I'm a weirdo, but I feel like commit messages don't typically end in a period?
* Not the end of the world, but seems slightly more correct

### Solution

* Simply strip from end of response